### PR TITLE
Add CSTN Signage plugin skeleton

### DIFF
--- a/admin/class-cstn-signage-admin.php
+++ b/admin/class-cstn-signage-admin.php
@@ -1,0 +1,395 @@
+<?php
+/**
+ * Admin functionality for CSTN Signage.
+ *
+ * @package    Cstn_Signage
+ * @subpackage Cstn_Signage/admin
+ */
+
+class Cstn_Signage_Admin {
+
+    /**
+     * Plugin slug.
+     *
+     * @var string
+     */
+    private $plugin_name;
+
+    /**
+     * Plugin version.
+     *
+     * @var string
+     */
+    private $version;
+
+    /**
+     * Capability helper.
+     *
+     * @var Cstn_Signage_Capabilities
+     */
+    private $capabilities;
+
+    /**
+     * Constructor.
+     *
+     * @param string $plugin_name Plugin slug.
+     * @param string $version     Plugin version.
+     */
+    public function __construct( $plugin_name, $version ) {
+        $this->plugin_name  = $plugin_name;
+        $this->version      = $version;
+        $this->capabilities = new Cstn_Signage_Capabilities();
+    }
+
+    /**
+     * Register custom post types.
+     */
+    public function register_post_types() {
+        $this->register_asset_post_type();
+        $this->register_playlist_post_type();
+        $this->register_channel_post_type();
+        $this->register_screen_post_type();
+    }
+
+    /**
+     * Register taxonomies.
+     */
+    public function register_taxonomies() {
+        $this->register_location_taxonomy();
+        $this->register_category_taxonomy();
+    }
+
+    /**
+     * Register admin menus.
+     */
+    public function register_menus() {
+        add_menu_page(
+            __( 'Signage', 'cstn-signage' ),
+            __( 'Signage', 'cstn-signage' ),
+            'edit_cstn_tv_assets',
+            'cstn-signage',
+            array( $this, 'render_assets_page_redirect' ),
+            'dashicons-welcome-view-site',
+            56
+        );
+
+        add_submenu_page(
+            'cstn-signage',
+            __( 'Assets', 'cstn-signage' ),
+            __( 'Assets', 'cstn-signage' ),
+            'edit_cstn_tv_assets',
+            'edit.php?post_type=cstn_tv_asset'
+        );
+
+        add_submenu_page(
+            'cstn-signage',
+            __( 'Playlists', 'cstn-signage' ),
+            __( 'Playlists', 'cstn-signage' ),
+            'edit_cstn_tv_playlists',
+            'edit.php?post_type=cstn_tv_playlist'
+        );
+
+        add_submenu_page(
+            'cstn-signage',
+            __( 'Channels', 'cstn-signage' ),
+            __( 'Channels', 'cstn-signage' ),
+            'edit_cstn_tv_channels',
+            'edit.php?post_type=cstn_tv_channel'
+        );
+
+        add_submenu_page(
+            'cstn-signage',
+            __( 'Screens', 'cstn-signage' ),
+            __( 'Screens', 'cstn-signage' ),
+            'edit_cstn_tv_screens',
+            'edit.php?post_type=cstn_tv_screen'
+        );
+
+        add_submenu_page(
+            'cstn-signage',
+            __( 'Settings', 'cstn-signage' ),
+            __( 'Settings', 'cstn-signage' ),
+            'manage_options',
+            'cstn-signage-settings',
+            array( $this, 'render_settings_page' )
+        );
+
+        remove_submenu_page( 'cstn-signage', 'cstn-signage' );
+    }
+
+    /**
+     * Redirect handler for the top-level menu click.
+     */
+    public function render_assets_page_redirect() {
+        if ( current_user_can( 'edit_cstn_tv_assets' ) ) {
+            wp_safe_redirect( admin_url( 'edit.php?post_type=cstn_tv_asset' ) );
+            exit;
+        }
+
+        wp_die( esc_html__( 'You do not have permission to access this page.', 'cstn-signage' ) );
+    }
+
+    /**
+     * Render settings page placeholder.
+     */
+    public function render_settings_page() {
+        echo '<div class="wrap"><h1>' . esc_html__( 'Signage Settings', 'cstn-signage' ) . '</h1><p>' . esc_html__( 'Settings interface coming soon.', 'cstn-signage' ) . '</p></div>';
+    }
+
+    /**
+     * Register metaboxes.
+     */
+    public function register_metaboxes() {
+        add_meta_box(
+            'cstn_tv_asset_details',
+            __( 'Asset Details', 'cstn-signage' ),
+            array( $this, 'render_asset_metabox' ),
+            'cstn_tv_asset'
+        );
+
+        add_meta_box(
+            'cstn_tv_playlist_items',
+            __( 'Playlist Items', 'cstn-signage' ),
+            array( $this, 'render_playlist_metabox' ),
+            'cstn_tv_playlist'
+        );
+
+        add_meta_box(
+            'cstn_tv_channel_assignment',
+            __( 'Channel Playlist Assignment', 'cstn-signage' ),
+            array( $this, 'render_channel_metabox' ),
+            'cstn_tv_channel'
+        );
+
+        add_meta_box(
+            'cstn_tv_screen_details',
+            __( 'Screen Details', 'cstn-signage' ),
+            array( $this, 'render_screen_metabox' ),
+            'cstn_tv_screen'
+        );
+    }
+
+    /**
+     * Render placeholder for asset meta box.
+     */
+    public function render_asset_metabox() {
+        echo '<p>' . esc_html__( 'Select asset type and source. Coming soon.', 'cstn-signage' ) . '</p>';
+    }
+
+    /**
+     * Render placeholder for playlist meta box.
+     */
+    public function render_playlist_metabox() {
+        echo '<p>' . esc_html__( 'Playlist builder coming soon.', 'cstn-signage' ) . '</p>';
+    }
+
+    /**
+     * Render placeholder for channel meta box.
+     */
+    public function render_channel_metabox() {
+        echo '<p>' . esc_html__( 'Assign playlists to this channel. Coming soon.', 'cstn-signage' ) . '</p>';
+    }
+
+    /**
+     * Render placeholder for screen meta box.
+     */
+    public function render_screen_metabox() {
+        echo '<p>' . esc_html__( 'Screen token and assignments coming soon.', 'cstn-signage' ) . '</p>';
+    }
+
+    /**
+     * Register the asset post type.
+     */
+    private function register_asset_post_type() {
+        $labels = array(
+            'name'               => __( 'Assets', 'cstn-signage' ),
+            'singular_name'      => __( 'Asset', 'cstn-signage' ),
+            'add_new'            => __( 'Add New', 'cstn-signage' ),
+            'add_new_item'       => __( 'Add New Asset', 'cstn-signage' ),
+            'edit_item'          => __( 'Edit Asset', 'cstn-signage' ),
+            'new_item'           => __( 'New Asset', 'cstn-signage' ),
+            'view_item'          => __( 'View Asset', 'cstn-signage' ),
+            'search_items'       => __( 'Search Assets', 'cstn-signage' ),
+            'not_found'          => __( 'No assets found.', 'cstn-signage' ),
+            'not_found_in_trash' => __( 'No assets found in Trash.', 'cstn-signage' ),
+        );
+
+        register_post_type(
+            'cstn_tv_asset',
+            array(
+                'labels'             => $labels,
+                'public'             => false,
+                'show_ui'            => true,
+                'show_in_menu'       => false,
+                'capability_type'    => 'cstn_tv_asset',
+                'map_meta_cap'       => true,
+                'supports'           => array( 'title', 'thumbnail' ),
+                'capabilities'       => $this->capabilities->get( 'asset' ),
+                'rewrite'            => false,
+                'show_in_rest'       => true,
+            )
+        );
+    }
+
+    /**
+     * Register the playlist post type.
+     */
+    private function register_playlist_post_type() {
+        $labels = array(
+            'name'               => __( 'Playlists', 'cstn-signage' ),
+            'singular_name'      => __( 'Playlist', 'cstn-signage' ),
+            'add_new'            => __( 'Add New', 'cstn-signage' ),
+            'add_new_item'       => __( 'Add New Playlist', 'cstn-signage' ),
+            'edit_item'          => __( 'Edit Playlist', 'cstn-signage' ),
+            'new_item'           => __( 'New Playlist', 'cstn-signage' ),
+            'view_item'          => __( 'View Playlist', 'cstn-signage' ),
+            'search_items'       => __( 'Search Playlists', 'cstn-signage' ),
+            'not_found'          => __( 'No playlists found.', 'cstn-signage' ),
+            'not_found_in_trash' => __( 'No playlists found in Trash.', 'cstn-signage' ),
+        );
+
+        register_post_type(
+            'cstn_tv_playlist',
+            array(
+                'labels'             => $labels,
+                'public'             => false,
+                'show_ui'            => true,
+                'show_in_menu'       => false,
+                'capability_type'    => 'cstn_tv_playlist',
+                'map_meta_cap'       => true,
+                'supports'           => array( 'title' ),
+                'capabilities'       => $this->capabilities->get( 'playlist' ),
+                'rewrite'            => false,
+                'show_in_rest'       => true,
+            )
+        );
+    }
+
+    /**
+     * Register the channel post type.
+     */
+    private function register_channel_post_type() {
+        $labels = array(
+            'name'               => __( 'Channels', 'cstn-signage' ),
+            'singular_name'      => __( 'Channel', 'cstn-signage' ),
+            'add_new'            => __( 'Add New', 'cstn-signage' ),
+            'add_new_item'       => __( 'Add New Channel', 'cstn-signage' ),
+            'edit_item'          => __( 'Edit Channel', 'cstn-signage' ),
+            'new_item'           => __( 'New Channel', 'cstn-signage' ),
+            'view_item'          => __( 'View Channel', 'cstn-signage' ),
+            'search_items'       => __( 'Search Channels', 'cstn-signage' ),
+            'not_found'          => __( 'No channels found.', 'cstn-signage' ),
+            'not_found_in_trash' => __( 'No channels found in Trash.', 'cstn-signage' ),
+        );
+
+        register_post_type(
+            'cstn_tv_channel',
+            array(
+                'labels'             => $labels,
+                'public'             => false,
+                'show_ui'            => true,
+                'show_in_menu'       => false,
+                'capability_type'    => 'cstn_tv_channel',
+                'map_meta_cap'       => true,
+                'supports'           => array( 'title' ),
+                'capabilities'       => $this->capabilities->get( 'channel' ),
+                'rewrite'            => false,
+                'show_in_rest'       => true,
+            )
+        );
+    }
+
+    /**
+     * Register the screen post type.
+     */
+    private function register_screen_post_type() {
+        $labels = array(
+            'name'               => __( 'Screens', 'cstn-signage' ),
+            'singular_name'      => __( 'Screen', 'cstn-signage' ),
+            'add_new'            => __( 'Add New', 'cstn-signage' ),
+            'add_new_item'       => __( 'Add New Screen', 'cstn-signage' ),
+            'edit_item'          => __( 'Edit Screen', 'cstn-signage' ),
+            'new_item'           => __( 'New Screen', 'cstn-signage' ),
+            'view_item'          => __( 'View Screen', 'cstn-signage' ),
+            'search_items'       => __( 'Search Screens', 'cstn-signage' ),
+            'not_found'          => __( 'No screens found.', 'cstn-signage' ),
+            'not_found_in_trash' => __( 'No screens found in Trash.', 'cstn-signage' ),
+        );
+
+        register_post_type(
+            'cstn_tv_screen',
+            array(
+                'labels'             => $labels,
+                'public'             => false,
+                'show_ui'            => true,
+                'show_in_menu'       => false,
+                'capability_type'    => 'cstn_tv_screen',
+                'map_meta_cap'       => true,
+                'supports'           => array( 'title' ),
+                'capabilities'       => $this->capabilities->get( 'screen' ),
+                'rewrite'            => false,
+                'show_in_rest'       => true,
+            )
+        );
+    }
+
+    /**
+     * Register the location taxonomy.
+     */
+    private function register_location_taxonomy() {
+        $labels = array(
+            'name'          => __( 'Locations', 'cstn-signage' ),
+            'singular_name' => __( 'Location', 'cstn-signage' ),
+            'search_items'  => __( 'Search Locations', 'cstn-signage' ),
+            'all_items'     => __( 'All Locations', 'cstn-signage' ),
+            'edit_item'     => __( 'Edit Location', 'cstn-signage' ),
+            'update_item'   => __( 'Update Location', 'cstn-signage' ),
+            'add_new_item'  => __( 'Add New Location', 'cstn-signage' ),
+            'new_item_name' => __( 'New Location Name', 'cstn-signage' ),
+            'menu_name'     => __( 'Locations', 'cstn-signage' ),
+        );
+
+        register_taxonomy(
+            'cstn_location',
+            array( 'cstn_tv_channel', 'cstn_tv_screen' ),
+            array(
+                'labels'            => $labels,
+                'public'            => false,
+                'show_ui'           => true,
+                'show_admin_column' => true,
+                'hierarchical'      => true,
+                'show_in_rest'      => true,
+            )
+        );
+    }
+
+    /**
+     * Register the asset category taxonomy.
+     */
+    private function register_category_taxonomy() {
+        $labels = array(
+            'name'          => __( 'Asset Categories', 'cstn-signage' ),
+            'singular_name' => __( 'Asset Category', 'cstn-signage' ),
+            'search_items'  => __( 'Search Asset Categories', 'cstn-signage' ),
+            'all_items'     => __( 'All Asset Categories', 'cstn-signage' ),
+            'edit_item'     => __( 'Edit Asset Category', 'cstn-signage' ),
+            'update_item'   => __( 'Update Asset Category', 'cstn-signage' ),
+            'add_new_item'  => __( 'Add New Asset Category', 'cstn-signage' ),
+            'new_item_name' => __( 'New Asset Category', 'cstn-signage' ),
+            'menu_name'     => __( 'Asset Categories', 'cstn-signage' ),
+        );
+
+        register_taxonomy(
+            'cstn_category',
+            array( 'cstn_tv_asset' ),
+            array(
+                'labels'            => $labels,
+                'public'            => false,
+                'show_ui'           => true,
+                'show_admin_column' => true,
+                'hierarchical'      => true,
+                'show_in_rest'      => true,
+            )
+        );
+    }
+}

--- a/cstn-signage.php
+++ b/cstn-signage.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Plugin Name:       CSTN Signage
+ * Plugin URI:        https://centerstone.org
+ * Description:       Digital signage management tools for Centerstone.
+ * Version:           0.1.0
+ * Author:            Centerstone
+ * Author URI:        https://centerstone.org
+ * Text Domain:       cstn-signage
+ * Domain Path:       /languages
+ */
+
+if ( ! defined( 'WPINC' ) ) {
+    die;
+}
+
+/**
+ * Currently plugin version.
+ */
+define( 'CSTN_SIGNAGE_VERSION', '0.1.0' );
+
+/**
+ * Absolute path to the plugin file.
+ */
+define( 'CSTN_SIGNAGE_FILE', __FILE__ );
+
+/**
+ * Absolute path to the plugin directory.
+ */
+define( 'CSTN_SIGNAGE_DIR', plugin_dir_path( CSTN_SIGNAGE_FILE ) );
+
+/**
+ * URL to the plugin directory.
+ */
+define( 'CSTN_SIGNAGE_URL', plugin_dir_url( CSTN_SIGNAGE_FILE ) );
+
+/**
+ * The code that runs during plugin activation.
+ */
+function activate_cstn_signage() {
+    require_once CSTN_SIGNAGE_DIR . 'includes/class-cstn-signage-activator.php';
+    Cstn_Signage_Activator::activate();
+}
+
+/**
+ * The code that runs during plugin deactivation.
+ */
+function deactivate_cstn_signage() {
+    require_once CSTN_SIGNAGE_DIR . 'includes/class-cstn-signage-deactivator.php';
+    Cstn_Signage_Deactivator::deactivate();
+}
+
+register_activation_hook( CSTN_SIGNAGE_FILE, 'activate_cstn_signage' );
+register_deactivation_hook( CSTN_SIGNAGE_FILE, 'deactivate_cstn_signage' );
+
+require CSTN_SIGNAGE_DIR . 'includes/class-cstn-signage.php';
+
+/**
+ * Begins execution of the plugin.
+ */
+function run_cstn_signage() {
+    $plugin = new Cstn_Signage();
+    $plugin->run();
+}
+
+run_cstn_signage();

--- a/includes/class-cstn-signage-activator.php
+++ b/includes/class-cstn-signage-activator.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Fired during plugin activation
+ *
+ * @package    Cstn_Signage
+ * @subpackage Cstn_Signage/includes
+ */
+
+class Cstn_Signage_Activator {
+
+    /**
+     * Run tasks on plugin activation.
+     */
+    public static function activate() {
+        require_once CSTN_SIGNAGE_DIR . 'includes/class-cstn-signage-capabilities.php';
+        require_once CSTN_SIGNAGE_DIR . 'admin/class-cstn-signage-admin.php';
+
+        $admin = new Cstn_Signage_Admin( 'cstn-signage', CSTN_SIGNAGE_VERSION );
+        $admin->register_post_types();
+        $admin->register_taxonomies();
+
+        self::add_roles();
+        flush_rewrite_rules();
+    }
+
+    /**
+     * Create the Digital Signage Manager role with required capabilities.
+     */
+    private static function add_roles() {
+        $capability_manager = new Cstn_Signage_Capabilities();
+        $manager_caps       = array_fill_keys( $capability_manager->all_caps(), true );
+        $manager_caps['read']         = true;
+        $manager_caps['upload_files'] = true;
+
+        $role_cap_sets = array(
+            'administrator'           => $capability_manager->all_caps(),
+            'editor'                  => $capability_manager->get_capabilities_for( array( 'asset', 'playlist' ) ),
+            'digital_signage_manager' => $capability_manager->all_caps(),
+        );
+
+        foreach ( $role_cap_sets as $role_key => $caps ) {
+            $role = get_role( $role_key );
+
+            if ( ! $role && 'digital_signage_manager' === $role_key ) {
+                $role = add_role( 'digital_signage_manager', __( 'Digital Signage Manager', 'cstn-signage' ), array() );
+            }
+
+            if ( ! $role ) {
+                continue;
+            }
+
+            foreach ( $caps as $cap ) {
+                $role->add_cap( $cap );
+            }
+        }
+
+        $manager_role = get_role( 'digital_signage_manager' );
+        if ( $manager_role ) {
+            foreach ( $manager_caps as $cap => $grant ) {
+                $manager_role->add_cap( $cap, $grant );
+            }
+        }
+    }
+}

--- a/includes/class-cstn-signage-capabilities.php
+++ b/includes/class-cstn-signage-capabilities.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Capabilities helper for the CSTN Signage plugin.
+ *
+ * @package    Cstn_Signage
+ * @subpackage Cstn_Signage/includes
+ */
+
+class Cstn_Signage_Capabilities {
+
+    /**
+     * Map of entity keys to capability sets.
+     *
+     * @var array
+     */
+    private $map = array();
+
+    /**
+     * Constructor.
+     */
+    public function __construct() {
+        $this->map = array(
+            'asset'    => $this->generate_capabilities( 'cstn_tv_asset' ),
+            'playlist' => $this->generate_capabilities( 'cstn_tv_playlist' ),
+            'channel'  => $this->generate_capabilities( 'cstn_tv_channel' ),
+            'screen'   => $this->generate_capabilities( 'cstn_tv_screen' ),
+        );
+    }
+
+    /**
+     * Retrieve the capability map for a given entity key.
+     *
+     * @param string $key Entity key.
+     * @return array
+     */
+    public function get( $key ) {
+        return isset( $this->map[ $key ] ) ? $this->map[ $key ] : array();
+    }
+
+    /**
+     * Retrieve capabilities for a set of entity keys.
+     *
+     * @param array $keys Entity keys.
+     * @return array
+     */
+    public function get_capabilities_for( $keys ) {
+        $caps = array();
+        foreach ( $keys as $key ) {
+            $caps = array_merge( $caps, array_values( $this->get( $key ) ) );
+        }
+
+        return array_unique( $caps );
+    }
+
+    /**
+     * Get all custom capability strings registered by the plugin.
+     *
+     * @return array
+     */
+    public function all_caps() {
+        return $this->get_capabilities_for( array( 'asset', 'playlist', 'channel', 'screen' ) );
+    }
+
+    /**
+     * Generate capability map for a post type slug.
+     *
+     * @param string $type Post type slug.
+     * @return array
+     */
+    private function generate_capabilities( $type ) {
+        return array(
+            'edit_post'              => "edit_{$type}",
+            'read_post'              => "read_{$type}",
+            'delete_post'            => "delete_{$type}",
+            'edit_posts'             => "edit_{$type}s",
+            'edit_others_posts'      => "edit_others_{$type}s",
+            'publish_posts'          => "publish_{$type}s",
+            'read_private_posts'     => "read_private_{$type}s",
+            'delete_posts'           => "delete_{$type}s",
+            'delete_private_posts'   => "delete_private_{$type}s",
+            'delete_published_posts' => "delete_published_{$type}s",
+            'delete_others_posts'    => "delete_others_{$type}s",
+            'edit_private_posts'     => "edit_private_{$type}s",
+            'edit_published_posts'   => "edit_published_{$type}s",
+            'create_posts'           => "edit_{$type}s",
+        );
+    }
+}

--- a/includes/class-cstn-signage-deactivator.php
+++ b/includes/class-cstn-signage-deactivator.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Fired during plugin deactivation
+ *
+ * @package    Cstn_Signage
+ * @subpackage Cstn_Signage/includes
+ */
+
+class Cstn_Signage_Deactivator {
+
+    /**
+     * Run tasks on plugin deactivation.
+     */
+    public static function deactivate() {
+        flush_rewrite_rules();
+    }
+}

--- a/includes/class-cstn-signage-i18n.php
+++ b/includes/class-cstn-signage-i18n.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Define internationalization functionality.
+ *
+ * @package    Cstn_Signage
+ * @subpackage Cstn_Signage/includes
+ */
+
+class Cstn_Signage_I18n {
+
+    /**
+     * Load the plugin text domain for translation.
+     */
+    public function load_plugin_textdomain() {
+        load_plugin_textdomain( 'cstn-signage', false, basename( CSTN_SIGNAGE_DIR ) . '/languages/' );
+    }
+}

--- a/includes/class-cstn-signage-loader.php
+++ b/includes/class-cstn-signage-loader.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Register all actions and filters for the plugin.
+ *
+ * @package    Cstn_Signage
+ * @subpackage Cstn_Signage/includes
+ */
+
+class Cstn_Signage_Loader {
+
+    /**
+     * Actions registered with WordPress.
+     *
+     * @var array
+     */
+    protected $actions = array();
+
+    /**
+     * Filters registered with WordPress.
+     *
+     * @var array
+     */
+    protected $filters = array();
+
+    /**
+     * Add a new action to the collection.
+     *
+     * @param string  $hook          Hook name.
+     * @param object  $component     Component instance.
+     * @param string  $callback      Callback method.
+     * @param int     $priority      Hook priority.
+     * @param integer $accepted_args Accepted args.
+     */
+    public function add_action( $hook, $component, $callback, $priority = 10, $accepted_args = 1 ) {
+        $this->actions = $this->add( $this->actions, $hook, $component, $callback, $priority, $accepted_args );
+    }
+
+    /**
+     * Add a new filter to the collection.
+     *
+     * @param string  $hook          Hook name.
+     * @param object  $component     Component instance.
+     * @param string  $callback      Callback method.
+     * @param int     $priority      Hook priority.
+     * @param integer $accepted_args Accepted args.
+     */
+    public function add_filter( $hook, $component, $callback, $priority = 10, $accepted_args = 1 ) {
+        $this->filters = $this->add( $this->filters, $hook, $component, $callback, $priority, $accepted_args );
+    }
+
+    /**
+     * Register all hooks with WordPress.
+     */
+    public function run() {
+        foreach ( $this->filters as $hook ) {
+            add_filter( $hook['hook'], array( $hook['component'], $hook['callback'] ), $hook['priority'], $hook['accepted_args'] );
+        }
+
+        foreach ( $this->actions as $hook ) {
+            add_action( $hook['hook'], array( $hook['component'], $hook['callback'] ), $hook['priority'], $hook['accepted_args'] );
+        }
+    }
+
+    /**
+     * Utility method for storing hooks.
+     *
+     * @param array   $hooks         Hook collection.
+     * @param string  $hook          Hook name.
+     * @param object  $component     Component instance.
+     * @param string  $callback      Callback method name.
+     * @param int     $priority      Hook priority.
+     * @param integer $accepted_args Accepted args.
+     *
+     * @return array
+     */
+    private function add( $hooks, $hook, $component, $callback, $priority, $accepted_args ) {
+        $hooks[] = array(
+            'hook'          => $hook,
+            'component'     => $component,
+            'callback'      => $callback,
+            'priority'      => $priority,
+            'accepted_args' => $accepted_args,
+        );
+
+        return $hooks;
+    }
+}

--- a/includes/class-cstn-signage.php
+++ b/includes/class-cstn-signage.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * The core plugin class for CSTN Signage.
+ *
+ * @package    Cstn_Signage
+ * @subpackage Cstn_Signage/includes
+ */
+
+class Cstn_Signage {
+
+    /**
+     * Loader for registering hooks with WordPress.
+     *
+     * @var Cstn_Signage_Loader
+     */
+    protected $loader;
+
+    /**
+     * Unique identifier for the plugin.
+     *
+     * @var string
+     */
+    protected $plugin_name = 'cstn-signage';
+
+    /**
+     * Current version of the plugin.
+     *
+     * @var string
+     */
+    protected $version;
+
+    /**
+     * Constructor.
+     */
+    public function __construct() {
+        $this->version = CSTN_SIGNAGE_VERSION;
+
+        $this->load_dependencies();
+        $this->set_locale();
+        $this->define_admin_hooks();
+    }
+
+    /**
+     * Load plugin dependencies.
+     */
+    private function load_dependencies() {
+        require_once CSTN_SIGNAGE_DIR . 'includes/class-cstn-signage-loader.php';
+        require_once CSTN_SIGNAGE_DIR . 'includes/class-cstn-signage-i18n.php';
+        require_once CSTN_SIGNAGE_DIR . 'includes/class-cstn-signage-capabilities.php';
+        require_once CSTN_SIGNAGE_DIR . 'admin/class-cstn-signage-admin.php';
+
+        $this->loader = new Cstn_Signage_Loader();
+    }
+
+    /**
+     * Set up internationalization hooks.
+     */
+    private function set_locale() {
+        $plugin_i18n = new Cstn_Signage_I18n();
+        $this->loader->add_action( 'plugins_loaded', $plugin_i18n, 'load_plugin_textdomain' );
+    }
+
+    /**
+     * Register hooks for the admin area.
+     */
+    private function define_admin_hooks() {
+        $plugin_admin = new Cstn_Signage_Admin( $this->get_plugin_name(), $this->get_version() );
+
+        $this->loader->add_action( 'init', $plugin_admin, 'register_post_types' );
+        $this->loader->add_action( 'init', $plugin_admin, 'register_taxonomies' );
+        $this->loader->add_action( 'admin_menu', $plugin_admin, 'register_menus' );
+        $this->loader->add_action( 'add_meta_boxes', $plugin_admin, 'register_metaboxes' );
+    }
+
+    /**
+     * Run the loader to execute hooks with WordPress.
+     */
+    public function run() {
+        $this->loader->run();
+    }
+
+    /**
+     * Get plugin name.
+     *
+     * @return string
+     */
+    public function get_plugin_name() {
+        return $this->plugin_name;
+    }
+
+    /**
+     * Get plugin version.
+     *
+     * @return string
+     */
+    public function get_version() {
+        return $this->version;
+    }
+
+    /**
+     * Get loader instance.
+     *
+     * @return Cstn_Signage_Loader
+     */
+    public function get_loader() {
+        return $this->loader;
+    }
+}


### PR DESCRIPTION
## Summary
- add the CSTN Signage bootstrap with plugin constants and loader wiring
- implement activation routines, custom post types, taxonomies, menus, and metabox placeholders for signage entities
- define capability helpers to provision the Digital Signage Manager role and extend editor access to assets and playlists

## Testing
- php -l cstn-signage.php
- php -l admin/class-cstn-signage-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68d7fa54fa18832faa057583053522a6